### PR TITLE
RFC 8941: セクション 4.2.7 翻訳

### DIFF
--- a/docs/rfc8941.html
+++ b/docs/rfc8941.html
@@ -3829,20 +3829,20 @@ input_stringは解析済みの値を除去するために変更されます。</
       and parse (<a href="#text-parse-en">Section 4.2</a>) functions. They
       need not be functions; for example, it could be implemented as an
       object, with methods for each of the different top-level types.</p></div>
-<div lang="ja" class="col"><p>この仕様の汎用実装は、トップレベルのシリアライズ(<a href="#text-serialize-ja">Section 4.1</a>)とパース(<a href="#text-parse-ja">Section 4.2</a>)関数を公開する必要があります。これらは関数である必要はありません。たとえば、異なるトップレベルの型のそれぞれに対するメソッドを持つオブジェクトとして実装することができます。</p></div>
+<div lang="ja" class="col"><p>この仕様の汎用実装は、トップレベルのシリアライズ(<a href="#text-serialize-ja">Section 4.1</a>)とパース(<a href="#text-parse-ja">Section 4.2</a>)関数を公開する必要があります。これらは関数である必要はありません。たとえば、異なるトップレベルの型のそれぞれに対するメソッドを持つオブジェクトとして実装できます。</p></div>
 </div>
 <div class="row">
 <div lang="en" class="col"><p>For interoperability, it's important that generic implementations be
       complete and follow the algorithms closely; see <a href="#strict-en">Section 1.1</a>. To aid this, a common test suite is being maintained
-      by the community at <span>&lt;<a href="https://github.com/httpwg/structured-field-tests" class="eref">https://github.com/httpwg/structured-field-tests</a></span>&gt;</p></div>
-<div lang="ja" class="col"><p><a href="#strict-ja">Section 1.1</a>相互運用のためには、汎用的な実装が完全であり、アルゴリズムに忠実であることが重要である。これを支援するために、コミュニティによって共通のテストスイートが<span>&lt;<a href="https://github.com/httpwg/structured-field-tests" class="eref">https://github.com/httpwg/structured-field-tests</a></span>&gt;</p></div>
+      by the community at <span>&lt;<a href="https://github.com/httpwg/structured-field-tests" class="eref">https://github.com/httpwg/structured-field-tests</a></span>&gt;.</p></div>
+<div lang="ja" class="col"><p>相互運用のためには、汎用的な実装が完全であり、アルゴリズムに忠実であることが重要です（<a href="#strict-ja">Section 1.1</a>を参照）。これを支援するために、コミュニティによって共通のテストスイートが<span>&lt;<a href="https://github.com/httpwg/structured-field-tests" class="eref">https://github.com/httpwg/structured-field-tests</a></span>&gt; でメンテナンスされています。</p></div>
 </div>
 <div class="row">
 <div lang="en" class="col"><p>Implementers should note that Dictionaries and Parameters are
       order-preserving maps. Some fields may not convey meaning in the
       ordering of these data types, but it should still be exposed so 
       that it will be available to applications that need to use it.</p></div>
-<div lang="ja" class="col"><p>実装者は、DictionariesとParameterが順序を保持するマップであることに注意する必要がある。いくつかのフィールドは、これらのデータ型の順序で意味を伝えないかもしれませんが、それを使用する必要があるアプリケーションが利用できるように、まだ公開されるべきです。</p></div>
+<div lang="ja" class="col"><p>実装者は、DictionariesとParameterが順序を保持するマップであることに注意する必要があります。いくつかのフィールドは、これらのデータ型の順序で意味を伝えないかもしれませんが、それを使用する必要があるアプリケーションが利用できるように、まだ公開されるべきです。</p></div>
 </div>
 <div class="row">
 <div lang="en" class="col"><p>Likewise, implementations should note that it's important to preserve
@@ -3856,14 +3856,14 @@ input_stringは解析済みの値を除去するために変更されます。</
 <div lang="en" class="col"><p>The serialization algorithm is defined in a way that it is not
       strictly limited to the data types defined in <a href="#types-en">Section 3</a> in every case. For example, Decimals are designed to
       take broader input and round to allowed values.</p></div>
-<div lang="ja" class="col"><p>シリアライズアルゴリズムは、あらゆる場合に<a href="#types-ja">Section 3</a> で定義されたデータ型に厳密には限定されないように定義されている。たとえば、Decimalsはより広い入力を取り、許容される値に丸めるように設計されている。</p></div>
+<div lang="ja" class="col"><p>シリアライズアルゴリズムは、あらゆる場合に<a href="#types-ja">Section 3</a> で定義されたデータ型に厳密には限定されないように定義されています。たとえば、Decimalsはより広い入力を取り、許容される値に丸めるように設計されています。</p></div>
 </div>
 <div class="row">
 <div lang="en" class="col"><p>Implementations are allowed to limit the size of different
       structures, subject to the minimums defined for each type. When a
       structure exceeds an implementation limit, that structure fails parsing
       or serialization.</p></div>
-<div lang="ja" class="col"><p>実装は、各タイプに定義された最小値に従って、さまざまな構造体のサイズを制限することが許されている。構造体が実装上の制限を超えた場合、その構造体はパースやシリアライズに失敗する。</p></div>
+<div lang="ja" class="col"><p>実装は、各タイプに定義された最小値にしたがって、さまざまな構造体のサイズを制限することが許されています。構造体が実装上の制限を超えた場合、その構造体はパースやシリアライズに失敗します。</p></div>
 </div></section><section><span id="acknowledgements-en"></span><span id="acknowledgements-ja"></span><div class="row">
 <div lang="en" class="col"><h2 id="name-acknowledgements-en" lang="en">
 <a href="#name-acknowledgements-en" class="section-name selfRef">Acknowledgements</a>

--- a/docs/rfc8941.html
+++ b/docs/rfc8941.html
@@ -3524,10 +3524,8 @@ input_stringは解析済みの値を除去するために変更されます。</
             <li>input_stringの最初の「:」までを取り除き、その結果をb64_contentに代入します。ただし、「:」自体は含みません。</li>
             <li>input_stringの最初の「:」を取り除きます。</li>
             <li>もしb64_contentがALPHA、DIGIT、"+"、"/"、または"="以外の文字を含む場合、パースに失敗します。</li>
-            <li>Let binary_content be the result of base64-decoding <span>[<a href="#RFC4648-ja">RFC4648</a>]</span> b64_content, synthesizing
-	    padding if necessary (note the requirements about recipient
-	    behavior below). If base64 decoding fails, parsing fails.</li>
-            <li>Return binary_content.</li>
+            <li>binary_contentを、必要に応じてパディングを合成しながら、<span>[<a href="#RFC4648-ja">RFC4648</a>]</span> b64_contentをbase64デコードした結果とします（以下の受信者の動作に関する要件に注意してください）。base64デコードに失敗した場合、解析は失敗します。</li>
+            <li>binary_contentを返します。</li>
           </ol></div>
 </div>
 <div class="row">

--- a/scripts/xml2html.py
+++ b/scripts/xml2html.py
@@ -808,7 +808,7 @@ class HtmlWriter:
                 a.set('class', 'eref')
                 span = build('span')
                 span.text = '<'
-                span.tail = '>'
+                span.tail = '>' + x.tail
                 span.append(a)
                 h.append(span)
                 return span

--- a/src/ja/rfc8941.xml
+++ b/src/ja/rfc8941.xml
@@ -1270,10 +1270,8 @@ input_stringは解析済みの値を除去するために変更されます。</
             <li pn="section-4.2.7-2.4" derivedCounter="4.">input_stringの最初の「:」までを取り除き、その結果をb64_contentに代入します。ただし、「:」自体は含みません。</li>
             <li pn="section-4.2.7-2.5" derivedCounter="5.">input_stringの最初の「:」を取り除きます。</li>
             <li pn="section-4.2.7-2.6" derivedCounter="6.">もしb64_contentがALPHA、DIGIT、"+"、"/"、または"="以外の文字を含む場合、パースに失敗します。</li>
-            <li pn="section-4.2.7-2.7" derivedCounter="7.">Let binary_content be the result of base64-decoding <xref target="RFC4648" format="default" sectionFormat="of" derivedContent="RFC4648"/> b64_content, synthesizing
-	    padding if necessary (note the requirements about recipient
-	    behavior below). If base64 decoding fails, parsing fails.</li>
-            <li pn="section-4.2.7-2.8" derivedCounter="8.">Return binary_content.</li>
+            <li pn="section-4.2.7-2.7" derivedCounter="7.">binary_contentを、必要に応じてパディングを合成しながら、<xref target="RFC4648" format="default" sectionFormat="of" derivedContent="RFC4648"/> b64_contentをbase64デコードした結果とします（以下の受信者の動作に関する要件に注意してください）。base64デコードに失敗した場合、解析は失敗します。</li>
+            <li pn="section-4.2.7-2.8" derivedCounter="8.">binary_contentを返します。</li>
           </ol>
           <t indent="0" pn="section-4.2.7-3">base64の実装によっては、適切に"="パディングされていないエンコードされたデータを拒否することができないため(<xref target="RFC4648" sectionFormat="comma" section="3.2" format="default" derivedLink="https://rfc-editor.org/rfc/rfc4648#section-3.2" derivedContent="RFC4648"/> 参照)、パーサーは"="パディングが存在しない場合、そう設定できない場合を除いて失敗<bcp14>すべきではありません（SHOULD NOT）</bcp14>。</t>
           <t indent="0" pn="section-4.2.7-4">base64の実装によっては、0以外のパッドビットを持つエンコードされたデータを拒否することができないため(<xref target="RFC4648" sectionFormat="comma" section="3.5" format="default" derivedLink="https://rfc-editor.org/rfc/rfc4648#section-3.5" derivedContent="RFC4648"/> 参照)、パーサーは0以外のパッドビットが存在する場合、そのように設定できない場合を除き、<bcp14>すべきではありません（SHOULD NOT）</bcp14>。</t>

--- a/src/ja/rfc8941.xml
+++ b/src/ja/rfc8941.xml
@@ -1535,12 +1535,12 @@ input_stringは解析済みの値を除去するために変更されます。</
     </section>
     <section anchor="implementation-notes" numbered="true" removeInRFC="false" toc="include" pn="section-appendix.b">
       <name slugifiedName="name-implementation-notes">実装メモ</name>
-      <t indent="0" pn="section-appendix.b-1">この仕様の汎用実装は、トップレベルのシリアライズ(<xref target="text-serialize" format="default" sectionFormat="of" derivedContent="Section 4.1"/>)とパース(<xref target="text-parse" format="default" sectionFormat="of" derivedContent="Section 4.2"/>)関数を公開する必要があります。これらは関数である必要はありません。たとえば、異なるトップレベルの型のそれぞれに対するメソッドを持つオブジェクトとして実装することができます。</t>
-      <t indent="0" pn="section-appendix.b-2"><xref target="strict" format="default" sectionFormat="of" derivedContent="Section 1.1"/>相互運用のためには、汎用的な実装が完全であり、アルゴリズムに忠実であることが重要である。これを支援するために、コミュニティによって共通のテストスイートが<eref brackets="angle" target="https://github.com/httpwg/structured-field-tests"/> でメンテナンスされています。</t>
-      <t indent="0" pn="section-appendix.b-3">実装者は、DictionariesとParameterが順序を保持するマップであることに注意する必要がある。いくつかのフィールドは、これらのデータ型の順序で意味を伝えないかもしれませんが、それを使用する必要があるアプリケーションが利用できるように、まだ公開されるべきです。</t>
+      <t indent="0" pn="section-appendix.b-1">この仕様の汎用実装は、トップレベルのシリアライズ(<xref target="text-serialize" format="default" sectionFormat="of" derivedContent="Section 4.1"/>)とパース(<xref target="text-parse" format="default" sectionFormat="of" derivedContent="Section 4.2"/>)関数を公開する必要があります。これらは関数である必要はありません。たとえば、異なるトップレベルの型のそれぞれに対するメソッドを持つオブジェクトとして実装できます。</t>
+      <t indent="0" pn="section-appendix.b-2">相互運用のためには、汎用的な実装が完全であり、アルゴリズムに忠実であることが重要です（<xref target="strict" format="default" sectionFormat="of" derivedContent="Section 1.1"/>を参照）。これを支援するために、コミュニティによって共通のテストスイートが<eref brackets="angle" target="https://github.com/httpwg/structured-field-tests"/> でメンテナンスされています。</t>
+      <t indent="0" pn="section-appendix.b-3">実装者は、DictionariesとParameterが順序を保持するマップであることに注意する必要があります。いくつかのフィールドは、これらのデータ型の順序で意味を伝えないかもしれませんが、それを使用する必要があるアプリケーションが利用できるように、まだ公開されるべきです。</t>
       <t indent="0" pn="section-appendix.b-4">同様に、トークンと文字列の区別を維持することが重要であることに、実装者は注意すべきです。ほとんどのプログラミング言語は、他の型にうまく対応するネイティブな型を持っていますが、これらの型が分離したままであることを保証するために、ラッパー「トークン」オブジェクトを作成するか、関数のパラメーターを使用することが必要な場合があります。</t>
-      <t indent="0" pn="section-appendix.b-5">シリアライズアルゴリズムは、あらゆる場合に<xref target="types" format="default" sectionFormat="of" derivedContent="Section 3"/> で定義されたデータ型に厳密には限定されないように定義されている。たとえば、Decimalsはより広い入力を取り、許容される値に丸めるように設計されている。</t>
-      <t indent="0" pn="section-appendix.b-6">実装は、各タイプに定義された最小値に従って、さまざまな構造体のサイズを制限することが許されている。構造体が実装上の制限を超えた場合、その構造体はパースやシリアライズに失敗する。</t>
+      <t indent="0" pn="section-appendix.b-5">シリアライズアルゴリズムは、あらゆる場合に<xref target="types" format="default" sectionFormat="of" derivedContent="Section 3"/> で定義されたデータ型に厳密には限定されないように定義されています。たとえば、Decimalsはより広い入力を取り、許容される値に丸めるように設計されています。</t>
+      <t indent="0" pn="section-appendix.b-6">実装は、各タイプに定義された最小値にしたがって、さまざまな構造体のサイズを制限することが許されています。構造体が実装上の制限を超えた場合、その構造体はパースやシリアライズに失敗します。</t>
     </section>
     <section numbered="false" anchor="acknowledgements" removeInRFC="false" toc="include" pn="section-appendix.c">
       <name slugifiedName="name-acknowledgements">謝辞</name>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Enhanced clarity and readability of instructions for handling base64 content in the documentation.
	- Consolidated steps for processing input and output for better understanding.
	- Improved Japanese translations regarding the decoding of base64 data and its implications during parsing.
	- Updated rendering process to better preserve and display original XML content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->